### PR TITLE
Use new version of coffee-react-transform compatible with latest react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-cjsx-preprocessor",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A Karma preprocessor for compiling Coffee React CJSX files",
   "homepage": "https://github.com/mtscout6/karma-cjsx-preprocessor",
   "repository": {
@@ -15,7 +15,7 @@
     "karma": ">=0.11.14"
   },
   "dependencies": {
-    "coffee-react-transform": "^2.1.0",
+    "coffee-react-transform": "^3.3.0",
     "karma-coffee-preprocessor": "^0.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi
Can you please add suport for the latest version of coffee-react-transform.
It is causing conflict when used with react >= v0.13. It will be very helpful.
Thanks
